### PR TITLE
refactored reducer function in chess-game-context.sx

### DIFF
--- a/frontend/src/pages/Play/ChessGameComputer.jsx
+++ b/frontend/src/pages/Play/ChessGameComputer.jsx
@@ -24,9 +24,9 @@ const ChessGameComputer = () => {
         socket.connect();
         socket.emit('INIT', {color});
 
-        socket.onAny(evt => {
-            console.log("event", evt);
-        })
+        // socket.onAny(evt => {
+        //     console.log("event", evt);
+        // })
 
         socket.on("CHESS_BOT_MOVE", (data) => {
             handleOpponentMove(data, () => {
@@ -102,7 +102,7 @@ const ChessGameComputer = () => {
                             p="2px"
                             label={username}
                             icon={<Avatar radius="3px" >
-                                {username[0].toUpperCase()}
+                                {username?.at(0).toUpperCase()}
                             </Avatar>}
                             description={"description"}
                         />


### PR DESCRIPTION
The reducer function in chess-game-context.jsx previously accepted two different action types MOVE_PIECE and CAPTURE_PIECE. Due to this the caller has to verify whether a move is a simple move or a capture. Since, the dispatch was called in multilpe places, it is better to keep one action type MOVE_PIECE and move the differentiating logic to the reducer. Also this commit implements a playAudioCallback which receives an action string and plays an audio accordingly. This is passed to the dispatch function and it is the responsibility of the reducer to call it with an appropriate action.

closes #21 