### PR TITLE
Improved UI of player[computer] name. #25

### DIFF
--- a/frontend/src/pages/Play/ChessGameComputer.jsx
+++ b/frontend/src/pages/Play/ChessGameComputer.jsx
@@ -76,7 +76,7 @@ const ChessGameComputer = () => {
                             style={{ width: "500px" }}
                             p="2px"
                             // label={isWaiting ? "Waiting for opponent..." : opponent}
-                            icon={<Avatar radius="3px" >
+                            icon={<Avatar radius="3px" style={{ minWidth: "4.374rem" }} >
                                 Computer
                             </Avatar>}
                             description={"description"}

--- a/frontend/src/pages/Play/ChessGameComputer.jsx
+++ b/frontend/src/pages/Play/ChessGameComputer.jsx
@@ -76,9 +76,11 @@ const ChessGameComputer = () => {
                             style={{ width: "500px" }}
                             p="2px"
                             // label={isWaiting ? "Waiting for opponent..." : opponent}
-                            icon={<Avatar radius="3px" style={{ minWidth: "4.374rem" }} >
-                                Computer
-                            </Avatar>}
+                            // icon={<Avatar radius="3px" style={{ minWidth: "4.374rem" }} >
+                            //     Computer
+                            // </Avatar>}
+                            icon = { <img src="https://www.chess.com/bundles/web/images/color-icons/computer.2318c3b4.svg" alt="computer-icon" style={{height:"38px" , width:"38px" ,borderRadius:"3px"}} /> }
+
                             description={"description"}
                         />
                     </div>


### PR DESCRIPTION
issue:#25
Improving the UI of player[computer] name which was not clearly seen before . 
before:
![ss](https://github.com/moonpatel/ChessHub/assets/107425784/4b35a895-2913-437c-8dcc-4da01ccbe914)
after:
![ssw](https://github.com/moonpatel/ChessHub/assets/107425784/447aa810-cf09-418b-ac45-62e4b29c13d7)
