### PR TITLE
Add labels to chessboard

### DIFF
--- a/frontend/src/components/Cell.jsx
+++ b/frontend/src/components/Cell.jsx
@@ -9,7 +9,7 @@ import { SOCKET_EVENTS } from '../constants';
 
 const { CHESS_MOVE, GAME_END } = SOCKET_EVENTS;
 
-const Cell = ({ cell, callbacks, isFirstColumn, isFirstRow }) => {
+const Cell = ({ cell, callbacks, rowLabel, columnLabel }) => {
     let roomID = localStorage.getItem('roomID');
     let { square, type } = cell;
     const { getSquareColor, isSquareMarked, handleSquareClick } = useContext(ChessGameContext);
@@ -37,14 +37,14 @@ const Cell = ({ cell, callbacks, isFirstColumn, isFirstRow }) => {
             let color = theme.colors.lime;
             return { backgroundColor: squareColor === 'b' ? '#769854' : '#e8edcd', aspectRatio: '1/1' };
         }} onClick={handleClick} bg={squareColor === 'w' ? "white" : "gray"}>
-            {isFirstColumn && (
+            {rowLabel && (
                 <div style={{ position: 'absolute', left: '5px', top: '50%', transform: 'translateY(-50%)' }}>
-                    {8 - parseInt(square[1]) + 1}
+                    {rowLabel}
                 </div>
             )}
-            {isFirstRow && (
+            {columnLabel && (
                 <div style={{ position: 'absolute', top: '5px', left: '50%', transform: 'translateX(-50%)' }}>
-                    {String.fromCharCode('a'.charCodeAt(0) + parseInt(square[0]) - (isFirstColumn ? 0 : 1))}
+                    {columnLabel}
                 </div>
             )}
             {content}
@@ -64,8 +64,8 @@ Cell.propTypes = {
         type: PropTypes.oneOf(['p', 'r', 'n', 'b', 'q', 'k']),
         color: PropTypes.oneOf(['w', 'b']),
     }),
-    isFirstColumn: PropTypes.bool,
-    isFirstRow: PropTypes.bool,
+    rowLabel: PropTypes.string,
+    columnLabel: PropTypes.string,
 };
 
 export default Cell;

--- a/frontend/src/components/Cell.jsx
+++ b/frontend/src/components/Cell.jsx
@@ -53,6 +53,7 @@ const Cell = ({ cell, callbacks }) => {
                         fontWeight: 'bold',
                     }}
                 >
+                    
                     {rowLabel}
                     <br />
                     {columnLabel}

--- a/frontend/src/components/Cell.jsx
+++ b/frontend/src/components/Cell.jsx
@@ -53,7 +53,6 @@ const Cell = ({ cell, callbacks }) => {
                         fontWeight: 'bold',
                     }}
                 >
-                    
                     {rowLabel}
                     <br />
                     {columnLabel}

--- a/frontend/src/components/Cell.jsx
+++ b/frontend/src/components/Cell.jsx
@@ -1,26 +1,22 @@
-import React, { useContext } from 'react'
-
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import { socket } from '../socket';
 import { Box, Flex } from '@mantine/core';
-import { useDroppable } from '@dnd-kit/core'
-
+import { useDroppable } from '@dnd-kit/core';
 import Piece from './Piece';
 import { ChessGameContext } from '../context/chess-game-context';
-
 import { SOCKET_EVENTS } from '../constants';
-const { CHESS_MOVE, GAME_END } = SOCKET_EVENTS
+const { CHESS_MOVE, GAME_END } = SOCKET_EVENTS;
 
 const Cell = ({ cell, callbacks }) => {
     let roomID = localStorage.getItem('roomID');
     let { square, type } = cell;
-    const { getSquareColor, isSquareMarked, handleSquareClick } = useContext(ChessGameContext)
+    const { getSquareColor, isSquareMarked, handleSquareClick } = useContext(ChessGameContext);
     const { isOver, setNodeRef } = useDroppable({ id: square });
     let squareColor = getSquareColor(square);
-
     let marked = isSquareMarked(square);
     let borderColor = isOver ? '#77777744' : 'transparent';
-    let borderWidth = type ? '3px' : '5px'
+    let borderWidth = type ? '3px' : '5px';
 
     const handleClick = () => {
         handleSquareClick(square, callbacks.pieceClickCallback, () => {
@@ -30,34 +26,54 @@ const Cell = ({ cell, callbacks }) => {
 
     let content = null;
     if (marked && !type) {
-        content = <Mark />
+        content = <Mark />;
     } else if (type) {
-        content = <Piece cell={cell} />
+        content = <Piece cell={cell} />;
     }
+
+    // Calculate the label for the cell based on its position
+    const rowLabel = 8 - parseInt(square[1]);
+    const columnLabel = String.fromCharCode('a'.charCodeAt(0) + parseInt(square[0]));
 
     return (
         <Flex ref={setNodeRef} sx={theme => {
             let color = theme.colors.lime;
-            return { backgroundColor: squareColor === 'b' ? '#769854' : '#e8edcd', aspectRatio: '1/1' }
-        }} onClick={handleClick} bg={squareColor === 'w' ? "white" : "gray"} >
-            {content}
+            return { backgroundColor: squareColor === 'b' ? '#769854' : '#e8edcd', aspectRatio: '1/1' };
+        }} onClick={handleClick} bg={squareColor === 'w' ? "white" : "gray"}>
+            <div style={{ position: 'relative' }}>
+                {content}
+                <div
+                    style={{
+                        position: 'absolute',
+                        top: '50%',
+                        left: '50%',
+                        transform: 'translate(-50%, -50%)',
+                        color: squareColor === 'w' ? 'black' : 'white',
+                        fontSize: '12px',
+                        fontWeight: 'bold',
+                    }}
+                >
+                    {rowLabel}
+                    <br />
+                    {columnLabel}
+                </div>
+            </div>
         </Flex>
-    )
-}
+    );
+};
 
 const Mark = () => {
     return (
         <Box w="36%" h="36%" sx={{ backgroundColor: '#77777755', borderRadius: '100%' }} m="auto"></Box>
-    )
-}
+    );
+};
 
 Cell.propTypes = {
     cell: PropTypes.shape({
         square: PropTypes.string.isRequired,
         type: PropTypes.oneOf(['p', 'r', 'n', 'b', 'q', 'k']),
-        color: PropTypes.oneOf(['w', 'b'])
-    })
-}
+        color: PropTypes.oneOf(['w', 'b']),
+    }),
+};
 
-
-export default Cell
+export default Cell;

--- a/frontend/src/components/Cell.jsx
+++ b/frontend/src/components/Cell.jsx
@@ -6,9 +6,10 @@ import { useDroppable } from '@dnd-kit/core';
 import Piece from './Piece';
 import { ChessGameContext } from '../context/chess-game-context';
 import { SOCKET_EVENTS } from '../constants';
+
 const { CHESS_MOVE, GAME_END } = SOCKET_EVENTS;
 
-const Cell = ({ cell, callbacks }) => {
+const Cell = ({ cell, callbacks, isFirstColumn, isFirstRow }) => {
     let roomID = localStorage.getItem('roomID');
     let { square, type } = cell;
     const { getSquareColor, isSquareMarked, handleSquareClick } = useContext(ChessGameContext);
@@ -31,33 +32,22 @@ const Cell = ({ cell, callbacks }) => {
         content = <Piece cell={cell} />;
     }
 
-    // Calculate the label for the cell based on its position
-    const rowLabel = 8 - parseInt(square[1]);
-    const columnLabel = String.fromCharCode('a'.charCodeAt(0) + parseInt(square[0]));
-
     return (
         <Flex ref={setNodeRef} sx={theme => {
             let color = theme.colors.lime;
             return { backgroundColor: squareColor === 'b' ? '#769854' : '#e8edcd', aspectRatio: '1/1' };
         }} onClick={handleClick} bg={squareColor === 'w' ? "white" : "gray"}>
-            <div style={{ position: 'relative' }}>
-                {content}
-                <div
-                    style={{
-                        position: 'absolute',
-                        top: '50%',
-                        left: '50%',
-                        transform: 'translate(-50%, -50%)',
-                        color: squareColor === 'w' ? 'black' : 'white',
-                        fontSize: '12px',
-                        fontWeight: 'bold',
-                    }}
-                >
-                    {rowLabel}
-                    <br />
-                    {columnLabel}
+            {isFirstColumn && (
+                <div style={{ position: 'absolute', left: '5px', top: '50%', transform: 'translateY(-50%)' }}>
+                    {8 - parseInt(square[1]) + 1}
                 </div>
-            </div>
+            )}
+            {isFirstRow && (
+                <div style={{ position: 'absolute', top: '5px', left: '50%', transform: 'translateX(-50%)' }}>
+                    {String.fromCharCode('a'.charCodeAt(0) + parseInt(square[0]) - (isFirstColumn ? 0 : 1))}
+                </div>
+            )}
+            {content}
         </Flex>
     );
 };
@@ -74,6 +64,8 @@ Cell.propTypes = {
         type: PropTypes.oneOf(['p', 'r', 'n', 'b', 'q', 'k']),
         color: PropTypes.oneOf(['w', 'b']),
     }),
+    isFirstColumn: PropTypes.bool,
+    isFirstRow: PropTypes.bool,
 };
 
 export default Cell;


### PR DESCRIPTION
issue: #23 
In this updated Cell component, I calculate the row and column labels based on the square's position and display them as labels on the chessboard. These labels are positioned in the center of each cell, and their appearance can be customized using CSS styles as needed.